### PR TITLE
Update kiwid

### DIFF
--- a/Makefile.comp.inc
+++ b/Makefile.comp.inc
@@ -47,7 +47,7 @@ ifeq ($(DEBIAN_DEVSYS),$(DEVSYS))
         HAS_PROC = $(shell test -d $(KIWI_XC_REMOTE_FS)/proc/device-tree && echo true)
         ifeq ($(HAS_PROC),true)
             BBAI = $(shell cat $(KIWI_XC_REMOTE_FS)/proc/device-tree/model | grep -q -s "BeagleBone AI" && echo true)
-            RPI = $(shell cat $(KIWI_XC_REMOTE_FS)/proc/device-tree/model | grep -q -s "Raspberry Pi 3" && echo true)
+            RPI = $(shell cat $(KIWI_XC_REMOTE_FS)/proc/device-tree/model | grep -q -s "Raspberry Pi" && echo true)
         else
             BBAI = $(shell cat $(KIWI_XC_REMOTE_FS)/etc/debian_version | grep -q -s "9\." && echo true)
             RPI = $(shell cat $(KIWI_XC_REMOTE_FS)/etc/os-release | grep -q -s "raspbian" && echo true)
@@ -105,7 +105,7 @@ ifeq ($(DEBIAN_DEVSYS),$(DEBIAN))
 	CFLAGS += -DHOST
 
 	BBAI = $(shell cat /proc/device-tree/model | grep -q -s "BeagleBone AI" && echo true)
-	RPI = $(shell cat /proc/device-tree/model | grep -q -s "Raspberry Pi 3" && echo true)
+	RPI = $(shell cat /proc/device-tree/model | grep -q -s "Raspberry Pi" && echo true)
 	DEBIAN_7 = $(shell cat /etc/debian_version | grep -q -s "7\." && echo true)
 
 	ifeq ($(DEBIAN_7),true)

--- a/k
+++ b/k
@@ -28,7 +28,7 @@ if test ! -f /etc/dogtag; then
 	exit 0
 fi
 
-RPI=$(cat /proc/device-tree/model | grep -q -s "Raspberry Pi 3"; echo $?)
+RPI=$(cat /proc/device-tree/model | grep -q -s "Raspberry Pi"; echo $?)
 #echo "not RPI = ${RPI}"
 BBAI=$(cat /proc/device-tree/model | grep -q -s "BeagleBone AI"; echo $?)
 #echo "not BBAI = ${BBAI}"

--- a/unix_env/kiwid
+++ b/unix_env/kiwid
@@ -18,7 +18,7 @@ KIWID_ARGS="-bg"
 
 [ -x $KIWID_EXEC ] || exit 1
 
-RPI=$(cat /proc/device-tree/model | grep -q -s "Raspberry Pi 3" && echo true)
+RPI=$(cat /proc/device-tree/model | grep -q -s "Raspberry Pi" && echo true)
 BBAI=$(cat /proc/device-tree/model | grep -q -s "BeagleBone AI" && echo true)
 if [ "x${BBAI}" = "xtrue" ] ; then
 	echo "BBAI USE_SPIDEV"
@@ -91,7 +91,7 @@ case "$1" in
     elif [ "x${RPI}" = "xtrue" ] ; then
         modprobe i2c-dev
         modprobe at24
-	cat "1200000" > /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq
+	echo "1200000" > /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq
         # Original version of kiwisdr
         echo "24c32 0x54" > /sys/class/i2c-adapter/i2c-1/new_device
         # RaspSDR version


### PR DESCRIPTION
line 21:Replace "Raspberry Pi 3" to "Raspberry Pi" for all pi version compatibility (tested on pi 4 and pi 3)
line 94: use of cat make some error, use echo instead